### PR TITLE
ppp: backport security fixes

### DIFF
--- a/package/network/services/ppp/Makefile
+++ b/package/network/services/ppp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ppp
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/paulusmack/ppp

--- a/package/network/services/ppp/patches/700-radius-Prevent-buffer-overflow-in-rc_mksid.patch
+++ b/package/network/services/ppp/patches/700-radius-Prevent-buffer-overflow-in-rc_mksid.patch
@@ -1,0 +1,30 @@
+From 858976b1fc3107f1261aae337831959b511b83c2 Mon Sep 17 00:00:00 2001
+From: Paul Mackerras <paulus@ozlabs.org>
+Date: Sat, 4 Jan 2020 12:01:32 +1100
+Subject: [PATCH] radius: Prevent buffer overflow in rc_mksid()
+
+On some systems getpid() can return a value greater than 65535.
+Increase the size of buf[] to allow for this, and use slprintf()
+to make sure we never overflow it.
+
+Signed-off-by: Paul Mackerras <paulus@ozlabs.org>
+---
+ pppd/plugins/radius/util.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/pppd/plugins/radius/util.c b/pppd/plugins/radius/util.c
+index 6f976a712951..740131e8377c 100644
+--- a/pppd/plugins/radius/util.c
++++ b/pppd/plugins/radius/util.c
+@@ -73,9 +73,9 @@ void rc_mdelay(int msecs)
+ char *
+ rc_mksid (void)
+ {
+-  static char buf[15];
++  static char buf[32];
+   static unsigned short int cnt = 0;
+-  sprintf (buf, "%08lX%04X%02hX",
++  slprintf(buf, sizeof(buf), "%08lX%04X%02hX",
+ 	   (unsigned long int) time (NULL),
+ 	   (unsigned int) getpid (),
+ 	   cnt & 0xFF);

--- a/package/network/services/ppp/patches/701-pppd-Fix-bounds-check-in-EAP-code.patch
+++ b/package/network/services/ppp/patches/701-pppd-Fix-bounds-check-in-EAP-code.patch
@@ -1,0 +1,37 @@
+From 8d7970b8f3db727fe798b65f3377fe6787575426 Mon Sep 17 00:00:00 2001
+From: Paul Mackerras <paulus@ozlabs.org>
+Date: Mon, 3 Feb 2020 15:53:28 +1100
+Subject: [PATCH] pppd: Fix bounds check in EAP code
+
+Given that we have just checked vallen < len, it can never be the case
+that vallen >= len + sizeof(rhostname).  This fixes the check so we
+actually avoid overflowing the rhostname array.
+
+Reported-by: Ilja Van Sprundel <ivansprundel@ioactive.com>
+Signed-off-by: Paul Mackerras <paulus@ozlabs.org>
+---
+ pppd/eap.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/pppd/eap.c b/pppd/eap.c
+index 94407f56a336..1b93db01aebd 100644
+--- a/pppd/eap.c
++++ b/pppd/eap.c
+@@ -1420,7 +1420,7 @@ int len;
+ 		}
+ 
+ 		/* Not so likely to happen. */
+-		if (vallen >= len + sizeof (rhostname)) {
++		if (len - vallen >= sizeof (rhostname)) {
+ 			dbglog("EAP: trimming really long peer name down");
+ 			BCOPY(inp + vallen, rhostname, sizeof (rhostname) - 1);
+ 			rhostname[sizeof (rhostname) - 1] = '\0';
+@@ -1846,7 +1846,7 @@ int len;
+ 		}
+ 
+ 		/* Not so likely to happen. */
+-		if (vallen >= len + sizeof (rhostname)) {
++		if (len - vallen >= sizeof (rhostname)) {
+ 			dbglog("EAP: trimming really long peer name down");
+ 			BCOPY(inp + vallen, rhostname, sizeof (rhostname) - 1);
+ 			rhostname[sizeof (rhostname) - 1] = '\0';

--- a/package/network/services/ppp/patches/702-pppd-Ignore-received-EAP-messages-when-not-doing-EAP.patch
+++ b/package/network/services/ppp/patches/702-pppd-Ignore-received-EAP-messages-when-not-doing-EAP.patch
@@ -1,0 +1,61 @@
+From 8d45443bb5c9372b4c6a362ba2f443d41c5636af Mon Sep 17 00:00:00 2001
+From: Paul Mackerras <paulus@ozlabs.org>
+Date: Mon, 3 Feb 2020 16:31:42 +1100
+Subject: [PATCH] pppd: Ignore received EAP messages when not doing EAP
+
+This adds some basic checks to the subroutines of eap_input to check
+that we have requested or agreed to doing EAP authentication before
+doing any processing on the received packet.  The motivation is to
+make it harder for a malicious peer to disrupt the operation of pppd
+by sending unsolicited EAP packets.  Note that eap_success() already
+has a check that the EAP client state is reasonable, and does nothing
+(apart from possibly printing a debug message) if not.
+
+Signed-off-by: Paul Mackerras <paulus@ozlabs.org>
+---
+ pppd/eap.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/pppd/eap.c b/pppd/eap.c
+index 1b93db01aebd..082e95343120 100644
+--- a/pppd/eap.c
++++ b/pppd/eap.c
+@@ -1328,6 +1328,12 @@ int len;
+ 	int fd;
+ #endif /* USE_SRP */
+ 
++	/*
++	 * Ignore requests if we're not open
++	 */
++	if (esp->es_client.ea_state <= eapClosed)
++		return;
++
+ 	/*
+ 	 * Note: we update es_client.ea_id *only if* a Response
+ 	 * message is being generated.  Otherwise, we leave it the
+@@ -1736,6 +1742,12 @@ int len;
+ 	u_char dig[SHA_DIGESTSIZE];
+ #endif /* USE_SRP */
+ 
++	/*
++	 * Ignore responses if we're not open
++	 */
++	if (esp->es_server.ea_state <= eapClosed)
++		return;
++
+ 	if (esp->es_server.ea_id != id) {
+ 		dbglog("EAP: discarding Response %d; expected ID %d", id,
+ 		    esp->es_server.ea_id);
+@@ -2047,6 +2059,12 @@ u_char *inp;
+ int id;
+ int len;
+ {
++	/*
++	 * Ignore failure messages if we're not open
++	 */
++	if (esp->es_client.ea_state <= eapClosed)
++		return;
++
+ 	if (!eap_client_active(esp)) {
+ 		dbglog("EAP unexpected failure message in state %s (%d)",
+ 		    eap_state_name(esp->es_client.ea_state),

--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -203,6 +203,7 @@ ubnt,bullet-m-xw|\
 ubnt,nanostation-loco-m|\
 ubnt,nanostation-m|\
 ubnt,nanostation-m-xw|\
+ubnt,picostation-m|\
 ubnt,rocket-m)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "ubnt:red:link1" "wlan0" "1" "100"

--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -200,6 +200,7 @@ tplink,tl-wr842n-v2)
 	;;
 ubnt,bullet-m|\
 ubnt,bullet-m-xw|\
+ubnt,nanostation-loco-m|\
 ubnt,nanostation-m|\
 ubnt,nanostation-m-xw|\
 ubnt,rocket-m)

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -39,6 +39,7 @@ ath79_setup_interfaces()
 	ubnt,nanobeam-ac|\
 	ubnt,nanostation-ac-loco|\
 	ubnt,nanostation-loco-m|\
+	ubnt,picostation-m|\
 	ubnt,rocket-m|\
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-lr|\

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -38,6 +38,7 @@ ath79_setup_interfaces()
 	ubnt,lap-120|\
 	ubnt,nanobeam-ac|\
 	ubnt,nanostation-ac-loco|\
+	ubnt,nanostation-loco-m|\
 	ubnt,rocket-m|\
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-lr|\

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -175,6 +175,7 @@ case "$FIRMWARE" in
 	ubnt,bullet-m|\
 	ubnt,nanostation-loco-m|\
 	ubnt,nanostation-m|\
+	ubnt,picostation-m|\
 	ubnt,rocket-m)
 		ath9k_eeprom_extract "art" 4096 4096
 		;;

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -173,6 +173,7 @@ case "$FIRMWARE" in
 	tplink,tl-wr842n-v1|\
 	ubnt,airrouter|\
 	ubnt,bullet-m|\
+	ubnt,nanostation-loco-m|\
 	ubnt,nanostation-m|\
 	ubnt,rocket-m)
 		ath9k_eeprom_extract "art" 4096 4096

--- a/target/linux/ath79/dts/ar7241_ubnt_nanostation-loco-m.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_nanostation-loco-m.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7241_ubnt_xm_outdoor.dtsi"
+
+/ {
+	compatible = "ubnt,nanostation-loco-m", "ubnt,xm", "qca,ar7241";
+	model = "Ubiquiti Nanostation Loco M";
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};

--- a/target/linux/ath79/dts/ar7241_ubnt_picostation-m.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_picostation-m.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7241_ubnt_xm_outdoor.dtsi"
+
+/ {
+	compatible = "ubnt,picostation-m", "ubnt,xm", "qca,ar7241";
+	model = "Ubiquiti Picostation M";
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8.dts
@@ -22,9 +22,6 @@
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;
 
-		pinctrl-names = "default";
-		pinctrl-0 = <&jtag_disable_pins>;
-
 		reset {
 			label = "Reset";
 			linux,code = <KEY_RESTART>;
@@ -96,7 +93,14 @@
 };
 
 &gpio {
-	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&jtag_disable_pins &pmx_usb_power>;
+};
+
+&pinmux {
+	pmx_usb_power: usb_power {
+		pinctrl-single,bits = <0x4 0x0 0xff>;
+	};
 };
 
 &spi {

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr842n-v2.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr842n-v2.dts
@@ -22,9 +22,6 @@
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;
 
-		pinctrl-names = "default";
-		pinctrl-0 = <&jtag_disable_pins>;
-
 		reset {
 			label = "Reset";
 			linux,code = <KEY_RESTART>;
@@ -113,7 +110,14 @@
 };
 
 &gpio {
-	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&jtag_disable_pins &pmx_usb_power>;
+};
+
+&pinmux {
+	pmx_usb_power: usb_power {
+		pinctrl-single,bits = <0x4 0x0 0xff>;
+	};
 };
 
 &spi {

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -109,6 +109,14 @@ define Device/ubnt_rocket-m
 endef
 TARGET_DEVICES += ubnt_rocket-m
 
+define Device/ubnt_nanostation-loco-m
+  $(Device/ubnt-xm)
+  DEVICE_TITLE := Ubiquiti Nanostation Loco M
+  DEVICE_PACKAGES += rssileds
+  SUPPORTED_DEVICES += bullet-m
+endef
+TARGET_DEVICES += ubnt_nanostation-loco-m
+
 define Device/ubnt_nanostation-m
   $(Device/ubnt-xm)
   DEVICE_TITLE := Ubiquiti Nanostation M

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -101,6 +101,14 @@ define Device/ubnt_bullet-m-xw
 endef
 TARGET_DEVICES += ubnt_bullet-m-xw
 
+define Device/ubnt_picostation-m
+  $(Device/ubnt-xm)
+  DEVICE_TITLE := Ubiquiti Picostation M
+  DEVICE_PACKAGES += rssileds
+  SUPPORTED_DEVICES += bullet-m
+endef
+TARGET_DEVICES += ubnt_picostation-m
+
 define Device/ubnt_rocket-m
   $(Device/ubnt-xm)
   DEVICE_TITLE := Ubiquiti Rocket-M

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -103,6 +103,7 @@ define Device/avm_fritz300e
 	append-squashfs-fakeroot-be | pad-to 256 | \
 	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
   DEVICE_PACKAGES := fritz-tffs rssileds -swconfig
+  SUPPORTED_DEVICES += fritz300e
 endef
 TARGET_DEVICES += avm_fritz300e
 

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -60,6 +60,12 @@ define Build/wr1201-factory-header
 	mv $@.new $@
 endef
 
+define Build/netis-tail
+	echo -n $(1) >> $@
+	echo -n $(UIMAGE_NAME)-yun | $(STAGING_DIR_HOST)/bin/mkhash md5 | \
+		sed 's/../\\\\x&/g' | xargs echo -ne >> $@
+endef
+
 define Build/ubnt-erx-factory-image
 	if [ -e $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) -a "$$(stat -c%s $@)" -lt "$(KERNEL_SIZE)" ]; then \
 		echo '21001:6' > $(1).compat; \
@@ -544,6 +550,8 @@ define Device/wf-2881
   IMAGE_SIZE := 129280k
   KERNEL := $(KERNEL_DTB) | pad-offset $$(BLOCKSIZE) 64 | uImage lzma
   UBINIZE_OPTS := -E 5
+  UIMAGE_NAME := WF2881_0.0.00
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | netis-tail WF2881 | uImage lzma
   IMAGE/sysupgrade.bin := append-kernel | append-ubi | append-metadata | check-size $$$$(IMAGE_SIZE)
   DEVICE_TITLE := NETIS WF-2881
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic


### PR DESCRIPTION
8d45443bb5c9 pppd: Ignore received EAP messages when not doing EAP
8d7970b8f3db pppd: Fix bounds check in EAP code
858976b1fc31 radius: Prevent buffer overflow in rc_mksid()

Signed-off-by: Petr Štetiar <ynezz@true.cz>
(cherry picked from commit 215598fd03899c19a9cd26266221269dd5ec8cee)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
